### PR TITLE
Add llama.cpp provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ name = "Ollama"
 base_url = "http://localhost:11434/v1"
 ```
 
+If you are running a local [llama.cpp](https://github.com/ggerganov/llama.cpp)
+server, define a provider for it as well:
+
+```toml
+[model_providers.llama_cpp]
+name = "llama.cpp"
+base_url = "http://localhost:8080/v1"
+```
+
 The `base_url` will have `/chat/completions` appended to it to build the full URL for the request.
 
 For providers that also require an `Authorization` header of the form `Bearer: SECRET`, an `env_key` can be specified, which indicates the environment variable to read to use as the value of `SECRET` when making a request:

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -104,6 +104,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - azure
 > - gemini
 > - ollama
+> - llama_cpp
 > - mistral
 > - deepseek
 > - xai
@@ -419,6 +420,11 @@ Below is a comprehensive example of `config.json` with multiple custom providers
       "baseURL": "http://localhost:11434/v1",
       "envKey": "OLLAMA_API_KEY"
     },
+    "llama_cpp": {
+      "name": "llama.cpp",
+      "baseURL": "http://localhost:8080/v1",
+      "envKey": "LLAMA_CPP_API_KEY"
+    },
     "mistral": {
       "name": "Mistral",
       "baseURL": "https://api.mistral.ai/v1",
@@ -476,6 +482,9 @@ export AZURE_OPENAI_API_VERSION="2025-04-01-preview" (Optional)
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"
+
+# llama.cpp (no key required, but the variable can be set if desired)
+export LLAMA_CPP_API_KEY="dummy"
 
 # Similarly for other providers
 ```

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -382,7 +382,7 @@ if (cli.flags.free && provider.toLowerCase() === "openai") {
 }
 
 // Set of providers that don't require API keys
-const NO_API_KEY_REQUIRED = new Set(["ollama"]);
+const NO_API_KEY_REQUIRED = new Set(["ollama", "llama_cpp"]);
 
 // Skip API key validation for providers that don't require an API key
 if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -114,7 +114,7 @@ export function getApiKey(provider: string = "openai"): string | undefined {
   const providersConfig = config.providers ?? providers;
   const providerInfo = providersConfig[provider.toLowerCase()];
   if (providerInfo) {
-    if (providerInfo.name === "Ollama") {
+    if (providerInfo.name === "Ollama" || providerInfo.name === "llama.cpp") {
       return process.env[providerInfo.envKey] ?? "dummy";
     }
     return process.env[providerInfo.envKey];

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -27,6 +27,11 @@ export const providers: Record<
     baseURL: "http://localhost:11434/v1",
     envKey: "OLLAMA_API_KEY",
   },
+  llama_cpp: {
+    name: "llama.cpp",
+    baseURL: "http://localhost:8080/v1",
+    envKey: "LLAMA_CPP_API_KEY",
+  },
   mistral: {
     name: "Mistral",
     baseURL: "https://api.mistral.ai/v1",

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -56,6 +56,15 @@ name = "Ollama"
 base_url = "http://localhost:11434/v1"
 ```
 
+Likewise, a local [llama.cpp](https://github.com/ggerganov/llama.cpp) server can
+be added as:
+
+```toml
+[model_providers.llama_cpp]
+name = "llama.cpp"
+base_url = "http://localhost:8080/v1"
+```
+
 Or a third-party provider (using a distinct environment variable for the API key):
 
 ```toml


### PR DESCRIPTION
## Summary
- allow using a local `llama.cpp` server
- document how to configure the provider
- fix provider key to use `llama_cpp`

## Testing
- `pnpm run test` *(fails: raw-exec-process-group.test.ts)*
- `cargo test` *(fails: Sandbox(Denied) errors)*
- `cargo clippy --tests`
- `cargo fmt -- --config imports_granularity=Item`

------
https://chatgpt.com/codex/tasks/task_e_6870721396b88333bea10f9dac24cd34