### PR TITLE
Add build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ cargo clippy --tests
 cargo test
 ```
 
+Alternatively, run `./build.sh` from the repository root to execute the above
+steps automatically.
+
 </details>
 
 ---

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we run from the repository root
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_ROOT/codex-rs"
+
+# Install the Rust toolchain if necessary
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup component add rustfmt
+rustup component add clippy
+
+# Build Codex
+cargo build
+
+# Launch the TUI with a sample prompt
+cargo run --bin codex -- "explain this codebase to me"
+
+# Format and lint
+cargo fmt -- --config imports_granularity=Item
+cargo clippy --tests
+
+# Run the tests
+cargo test


### PR DESCRIPTION
## Summary
- add `build.sh` helper to compile the Rust workspace
- mention the new helper script in the build from source instructions

## Testing
- `cargo fmt`
- `cargo clippy --tests`
- `cargo test` *(fails: landlock tests)*

------
https://chatgpt.com/codex/tasks/task_e_68707e7d24c08333805abb9c4e7072bc